### PR TITLE
tx1: jetpack 3.3

### DIFF
--- a/scripts/jetson_variables
+++ b/scripts/jetson_variables
@@ -98,6 +98,8 @@ if [ -f /etc/nv_tegra_release ]; then
         esac
     elif [ "$JETSON_BOARD" = "TX1" ] ; then
         case $JETSON_L4T in
+            "28.2.0")
+                    JETSON_JETPACK="3.3" ;;
             "28.2") 
                     JETSON_JETPACK="3.2 or 3.2.1" ;;
             "28.1") 


### PR DESCRIPTION
Tested on my tx1 board with JetPack 3.3

Before:

daveti@tegra-ubuntu:~/git/jetsonUtilities$ python ./jetsonInfo.py
 NVIDIA Jetson TX1
 L4T 28.2.0 [ JetPack UNKNOWN ]
 Board: t210ref
 Ubuntu 16.04 LTS
 Kernel Version: 4.4.38-tegra
 CUDA 9.0.252

After:

daveti@tegra-ubuntu:~/git/ju/jetsonUtilities$ python ./jetsonInfo.py
 NVIDIA Jetson TX1
 L4T 28.2.0 [ JetPack 3.3 ]
 Board: t210ref
 Ubuntu 16.04 LTS
 Kernel Version: 4.4.38-tegra
 CUDA 9.0.252
