### PR TITLE
Update jetsonInfo.py

### DIFF
--- a/jetsonInfo.py
+++ b/jetsonInfo.py
@@ -27,7 +27,7 @@ for line in proc.stdout:
 proc.communicate()
 
 # Jetson Model
-print(" NVIDIA Jetson " + os.environ["JETSON_BOARD"].strip())
+print(" NVIDIA Jetson " + os.environ["JETSON_TYPE"].strip())
 
 #L4T Version
 print(' L4T ' + os.environ['JETSON_L4T'].strip() + ' [ JetPack ' +os.environ['JETSON_JETPACK'].strip()+' ]')


### PR DESCRIPTION
Change JETSON_BOARD to JETSON_TYPE to get exact correct information about Jetson devices.

For Jetson Nano, it outputs TX1 which is confusing.
 NVIDIA Jetson TX1
 L4T 32.1.0 [ JetPack 4.2 ]
 Ubuntu 18.04.2 LTS
 Kernel Version: 4.9.140-tegra
 CUDA 10.0.166

With this change, we get:
 NVIDIA Jetson NANO/TX1
 L4T 32.1.0 [ JetPack 4.2 ]
 Ubuntu 18.04.2 LTS
 Kernel Version: 4.9.140-tegra
 CUDA 10.0.166

which is consistent.